### PR TITLE
Feature/text field input

### DIFF
--- a/designsystem/src/main/kotlin/com/natura/android/textfield/TextFieldInput.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/textfield/TextFieldInput.kt
@@ -31,12 +31,12 @@ class TextFieldInput @JvmOverloads constructor(
     enum class LayoutState(val borderWidth: Int, val borderColor: Int, val labelColor: Int, val textColor: Int, val footerColor: Int) {
         DEFAULT(R.dimen.ds_border_tiny, R.color.colorHighEmphasis, R.color.colorMediumEmphasis, R.color.colorHighEmphasis, R.color.colorMediumEmphasis),
         DISABLED(R.dimen.ds_border_tiny, R.color.colorLowEmphasis, R.color.colorLowEmphasis, R.color.colorLowEmphasis, R.color.colorLowEmphasis),
-        FOCUSED(R.dimen.ds_border_emphasis, R.color.colorBrdNatOrange, R.color.colorMediumEmphasis, R.color.colorHighEmphasis, R.color.colorMediumEmphasis),
+        FOCUSED(R.dimen.ds_border_emphasis, R.color.colorBrdNatYellow, R.color.colorMediumEmphasis, R.color.colorHighEmphasis, R.color.colorMediumEmphasis),
         ERROR(R.dimen.ds_border_emphasis, R.color.colorBrdNatRed, R.color.colorBrdNatRed, R.color.colorHighEmphasis, R.color.colorBrdNatRed),
         SUCCESS(R.dimen.ds_border_tiny, R.color.colorBrdNatGreen, R.color.colorBrdNatGreen, R.color.colorHighEmphasis, R.color.colorBrdNatGreen)
     }
 
-    private val SUCCESS_ICON = "EA1A"
+    private val SUCCESS_ICON = "EA15"
     private val ERROR_ICON = "EA13"
 
     private val inputLabel by lazy { findViewById<TextView>(R.id.text_field_input_label) }
@@ -122,7 +122,7 @@ class TextFieldInput @JvmOverloads constructor(
             field = value
             inputLabel?.setTextColor(ContextCompat.getColor(context, value.labelColor))
             (inputBox.background as GradientDrawable).setStroke(
-                resources.getDimensionPixelSize(value.borderWidth),
+                resources.getDimension(value.borderWidth).toInt(),
                 ContextCompat.getColor(context, value.borderColor))
             footerValue?.setTextColor(ContextCompat.getColor(context, value.footerColor))
             footerIcon?.setTextColor(ContextCompat.getColor(context, value.footerColor))

--- a/designsystem/src/main/res/values/colors.xml
+++ b/designsystem/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorBrdNatRed">#e74627</color>
-    <color name="colorBrdNatGreen">#8BC34A</color>
+    <color name="colorBrdNatGreen">#569A32</color>
     <color name="colorBrdNatOrange">#FF6B0B</color>
     <color name="colorBrdNatYellow">#F4AB34</color>
     <color name="colorBrdNatWhite">#FFFFFF</color>

--- a/designsystem/src/test/kotlin/com/natura/android/textfield/TextFieldInputTest.kt
+++ b/designsystem/src/test/kotlin/com/natura/android/textfield/TextFieldInputTest.kt
@@ -29,7 +29,7 @@ class TextFieldInputTest {
     val EMPTY_TEXT = ""
     val NOT_EMPTY_TEXT = "test"
     val ERROR_ICON_CODE = "EA13"
-    val SUCCESS_ICON_CODE = "EA1A"
+    val SUCCESS_ICON_CODE = "EA15"
 
     @Test
     fun basicLayout() {


### PR DESCRIPTION
Correcoes apos revisao do COE

- Verificar se no campo selecionado o border está indo para valor 2
- O border de campo selecionado deve ser a cor primária do tema (Amarelo) está laranja.
- Confirmar cor de sucesso #569A32
- Corrigir ícone de sucesso (o icone correto é outlined-action-check)