### PR TITLE
chore: add support to Typo CI

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -5,4 +5,4 @@ excluded_words:
   - appbar
   - appcompat
   - natura
-  
+  - robolectric

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -1,0 +1,8 @@
+dictionaries:
+  - en
+excluded_words:
+  - androidx
+  - appbar
+  - appcompat
+  - natura
+  


### PR DESCRIPTION
This PR add support to Typo CI to prevent marking "natura", "appcompat", "androidx" and another valid words (for this repo context) as typos.