### PR TITLE
[DSY-1229] ExpansionPanel's state handling methods

### DIFF
--- a/designsystem/src/main/kotlin/com/natura/android/expansionPanel/ExpansionPanel.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/expansionPanel/ExpansionPanel.kt
@@ -22,11 +22,17 @@ class ExpansionPanel @JvmOverloads constructor(
     private val contentArea by lazy { findViewById<ConstraintLayout>(R.id.ds_expansion_panel_content_area) }
     private val title by lazy { findViewById<TextView>(R.id.ds_expansion_panel_title) }
 
+    private var onStateChangeListener: (isExpanded: Boolean) -> Unit = {}
+
     init {
         View.inflate(context, R.layout.ds_expansion_panel, this)
 
         setupSubtitle(context, attrs)
         setupClickableComponents()
+    }
+
+    fun setOnStateChangeListener(listener: (Boolean) -> Unit) {
+        onStateChangeListener = listener
     }
 
     fun isExpanded(): Boolean = contentArea.visibility == View.VISIBLE
@@ -67,12 +73,16 @@ class ExpansionPanel @JvmOverloads constructor(
         contentArea.visibility = View.VISIBLE
         icon.setImageResource(R.drawable.ds_ic_outlined_navigation_arrowtop)
         container.setBackgroundResource(R.drawable.ds_expansion_panel_border_expanded)
+
+        onStateChangeListener.invoke(true)
     }
 
     private fun hideContentArea() {
         contentArea.visibility = View.GONE
         icon.setImageResource(R.drawable.ds_ic_outlined_navigation_arrowbottom)
         container.setBackgroundResource(R.drawable.ds_expansion_panel_border_collapsed)
+
+        onStateChangeListener.invoke(false)
     }
 
     private fun moveGivenChildrenToContentArea() {

--- a/designsystem/src/main/kotlin/com/natura/android/expansionPanel/ExpansionPanel.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/expansionPanel/ExpansionPanel.kt
@@ -29,6 +29,8 @@ class ExpansionPanel @JvmOverloads constructor(
         setupClickableComponents()
     }
 
+    fun isExpanded(): Boolean = contentArea.visibility == View.VISIBLE
+
     override fun onFinishInflate() {
         super.onFinishInflate()
         moveGivenChildrenToContentArea()
@@ -54,14 +56,12 @@ class ExpansionPanel @JvmOverloads constructor(
     }
 
     private fun toggleContentArea() {
-        if (isContentAreaVisible()) {
+        if (isExpanded()) {
             hideContentArea()
         } else {
             showContentArea()
         }
     }
-
-    private fun isContentAreaVisible(): Boolean = contentArea.visibility == View.VISIBLE
 
     private fun showContentArea() {
         contentArea.visibility = View.VISIBLE

--- a/designsystem/src/main/kotlin/com/natura/android/expansionPanel/ExpansionPanel.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/expansionPanel/ExpansionPanel.kt
@@ -24,6 +24,16 @@ class ExpansionPanel @JvmOverloads constructor(
 
     private var onStateChangeListener: (isExpanded: Boolean) -> Unit = {}
 
+    var isExpanded: Boolean
+        get() = contentArea.visibility == View.VISIBLE
+        set(value) {
+            if (value) {
+                showContentArea()
+            } else {
+                hideContentArea()
+            }
+        }
+
     init {
         View.inflate(context, R.layout.ds_expansion_panel, this)
 
@@ -34,8 +44,6 @@ class ExpansionPanel @JvmOverloads constructor(
     fun setOnStateChangeListener(listener: (Boolean) -> Unit) {
         onStateChangeListener = listener
     }
-
-    fun isExpanded(): Boolean = contentArea.visibility == View.VISIBLE
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -62,7 +70,7 @@ class ExpansionPanel @JvmOverloads constructor(
     }
 
     private fun toggleContentArea() {
-        if (isExpanded()) {
+        if (isExpanded) {
             hideContentArea()
         } else {
             showContentArea()

--- a/designsystem/src/test/kotlin/com/natura/android/expansionPanel/ExpansionPanelTest.kt
+++ b/designsystem/src/test/kotlin/com/natura/android/expansionPanel/ExpansionPanelTest.kt
@@ -67,6 +67,18 @@ class ExpansionPanelTest {
     }
 
     @Test
+    fun invokeListenerWhenOnClick() {
+        var isPanelExpanded = false
+        expansionPanel.setOnStateChangeListener { isPanelExpanded = it }
+
+        val container = expansionPanel.findViewById(R.id.ds_expansion_panel_container) as View
+
+        container.callOnClick()
+
+        Truth.assertThat(isPanelExpanded).isTrue()
+    }
+
+    @Test
     fun withBorderWhenExpanded() {
         val expectedBackground = ContextCompat.getDrawable(activityController.get(), R.drawable.ds_expansion_panel_border_expanded)
 
@@ -87,5 +99,19 @@ class ExpansionPanelTest {
         val content = expansionPanel.findViewById(R.id.ds_expansion_panel_content_area) as ConstraintLayout
 
         Truth.assertThat(content.visibility).isEqualTo(View.GONE)
+    }
+
+    @Test
+    fun invokeListenerWhenOnClickAfterBeingExpanded() {
+        var isPanelExpanded = false
+        expansionPanel.setOnStateChangeListener { isPanelExpanded = it }
+
+        val container = expansionPanel.findViewById(R.id.ds_expansion_panel_container) as View
+
+        container.callOnClick()
+        Truth.assertThat(isPanelExpanded).isTrue()
+
+        container.callOnClick()
+        Truth.assertThat(isPanelExpanded).isFalse()
     }
 }

--- a/designsystem/src/test/kotlin/com/natura/android/expansionPanel/ExpansionPanelTest.kt
+++ b/designsystem/src/test/kotlin/com/natura/android/expansionPanel/ExpansionPanelTest.kt
@@ -41,6 +41,7 @@ class ExpansionPanelTest {
         val content = expansionPanel.findViewById(R.id.ds_expansion_panel_content_area) as ConstraintLayout
 
         Truth.assertThat(content.visibility).isEqualTo(View.GONE)
+        Truth.assertThat(expansionPanel.isExpanded).isFalse()
     }
 
     @Test
@@ -60,6 +61,15 @@ class ExpansionPanelTest {
         val container = expansionPanel.findViewById(R.id.ds_expansion_panel_container) as View
 
         container.callOnClick()
+
+        val content = expansionPanel.findViewById(R.id.ds_expansion_panel_content_area) as ConstraintLayout
+
+        Truth.assertThat(content.visibility).isEqualTo(View.VISIBLE)
+    }
+
+    @Test
+    fun showContentWhenSetExpanded() {
+        expansionPanel.isExpanded = true
 
         val content = expansionPanel.findViewById(R.id.ds_expansion_panel_content_area) as ConstraintLayout
 
@@ -95,6 +105,16 @@ class ExpansionPanelTest {
 
         container.callOnClick()
         container.callOnClick()
+
+        val content = expansionPanel.findViewById(R.id.ds_expansion_panel_content_area) as ConstraintLayout
+
+        Truth.assertThat(content.visibility).isEqualTo(View.GONE)
+    }
+
+    @Test
+    fun hideContentWhenSetCollapsed() {
+        expansionPanel.isExpanded = true
+        expansionPanel.isExpanded = false
 
         val content = expansionPanel.findViewById(R.id.ds_expansion_panel_content_area) as ConstraintLayout
 

--- a/doc/expansion-panel.md
+++ b/doc/expansion-panel.md
@@ -53,12 +53,16 @@ and TextField children:
 
 ### How to handle state
 
-You can get the ExpansionPanel's current state by calling the `isExpanded()` method.
+You can get or set the ExpansionPanel's current state by using the `isExpanded` attribute.
 
 ```kotlin
-val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
+fun expandFirstExpansionPanel() {
+    val expansionPanel = findViewById<ExpansionPanel>(R.id.first_expansion_panel)
+    expansionPanel.isExpanded = true
+}
 
-val currentState = if (expansionPanel.isExpanded()) "expanded" else "collapsed"
+val expansionPanel = findViewById<ExpansionPanel>(R.id.second_expansion_panel)
+val secondExpansionPanelState = if (secondExpansionPanel.isExpanded) "expanded" else "collapsed"
 ```
 
 Set a `OnStateChangeListener` if you need to be notified when the state changes.

--- a/doc/expansion-panel.md
+++ b/doc/expansion-panel.md
@@ -1,4 +1,4 @@
-# Expansion Panel - How to Use
+# Expansion Panel
 
 ### What is it?
 Expansion Panel is a component to display a title when collapsed and
@@ -50,3 +50,23 @@ and TextField children:
 
 #### Opened:
 [![Expanded](expansion_panel_opened.png)](https://postimg.cc/kR45M5mH)
+
+### How to handle state
+
+You can get the ExpansionPanel's current state by calling the `isExpanded()` method.
+
+```kotlin
+val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
+
+val currentState = if (expansionPanel.isExpanded()) "expanded" else "collapsed"
+```
+
+Set a `OnStateChangeListener` if you need to be notified when the state changes.
+
+```kotlin
+val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
+
+expansionPanel.setOnStateChangeListener { isExpanded ->
+    // isExpanded is the current state of the ExpansionPanel.
+}
+```

--- a/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
@@ -91,4 +91,68 @@ class ExpansionPanelActivityTest {
             isDescendantOfA(withId(R.id.first_expansion_panel))
         )).check(matches(not(isDisplayed())))
     }
+
+    @Test
+    fun shouldCollapseExpandedFirstPanelWhenTheSecondOneExpands() {
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).perform(click())
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.second_expansion_panel))
+        )).perform(click())
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(not(isDisplayed())))
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.second_expansion_panel))
+        )).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldCollapseExpandedSecondPanelWhenTheFirstOneExpands() {
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.second_expansion_panel))
+        )).perform(click())
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).perform(click())
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.second_expansion_panel))
+        )).check(matches(not(isDisplayed())))
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldNotExpandOneExpansionPanelWhenCollapsingAnother() {
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).perform(click()).perform(click())
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.second_expansion_panel))
+        )).check(matches(not(isDisplayed())))
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(not(isDisplayed())))
+    }
 }

--- a/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
@@ -26,73 +27,68 @@ class ExpansionPanelActivityTest {
 
     @Test
     fun shouldRenderSubtitle() {
-        onView(withId(R.id.ds_expansion_panel_title)).check(matches(withText("Expansion Panel")))
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_title),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(withText("Expansion Panel 1")))
     }
 
     @Test
     fun shouldRenderCollapsed() {
-        onView(withId(R.id.ds_expansion_panel_content_area)).check(matches(not(isDisplayed())))
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(not(isDisplayed())))
+
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.second_expansion_panel))
+        )).check(matches(not(isDisplayed())))
     }
 
     @Test
     fun shouldExpandContent() {
-        onView(withId(R.id.ds_expansion_panel_container)).perform(click())
-        onView(withId(R.id.ds_expansion_panel_content_area)).check(matches(isDisplayed()))
-    }
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).perform(click())
 
-    @Test
-    fun shouldDisplayToastWhenExpandingContent() {
-        onView(withId(R.id.ds_expansion_panel_container)).perform(click())
-
-        onView(withId(R.id.last_action_text)).check(matches(withText("The panel expanded.")))
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(isDisplayed()))
     }
 
     @Test
     fun shouldRenderGivenComponentsInsideContainer() {
-        onView(withId(R.id.ds_expansion_panel_container)).perform(click())
-        onView(allOf(withId(R.id.circle_example), withParent(withId(R.id.ds_expansion_panel_content_area))))
-            .check(matches(isDisplayed()))
-        onView(allOf(withId(R.id.text_example), withParent(withId(R.id.ds_expansion_panel_content_area))))
-            .check(matches(isDisplayed()))
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).perform(click())
+
+        onView(allOf(
+            withId(R.id.circle_example),
+            withParent(withId(R.id.ds_expansion_panel_content_area)),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(isDisplayed()))
+
+        onView(allOf(
+            withId(R.id.text_example),
+            withParent(withId(R.id.ds_expansion_panel_content_area)),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(isDisplayed()))
     }
 
     @Test
     fun shouldRenderCollapseWhenClickedOnExpandedContent() {
-        onView(withId(R.id.ds_expansion_panel_container)).perform(click()).perform(click())
-        onView(withId(R.id.ds_expansion_panel_content_area)).check(matches(not(isDisplayed())))
-    }
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_container),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).perform(click()).perform(click())
 
-    @Test
-    fun shouldDisplayToastWhenCollapsingContent() {
-        onView(withId(R.id.ds_expansion_panel_container))
-            .perform(click())
-            .perform(click())
-
-        onView(withId(R.id.last_action_text)).check(matches(withText("The panel collapsed.")))
-    }
-
-    @Test
-    fun shouldDisplayCollapsedWhenClickingButtonOnLaunch() {
-        onView(withId(R.id.current_state_button)).perform(click())
-
-        onView(withId(R.id.current_state_text)).check(matches(withText("The panel is collapsed.")))
-    }
-
-    @Test
-    fun shouldDisplayStateWhenClickingButtonWithExpandedPanel() {
-        onView(withId(R.id.ds_expansion_panel_container)).perform(click())
-        onView(withId(R.id.current_state_button)).perform(click())
-
-        onView(withId(R.id.current_state_text)).check(matches(withText("The panel is expanded.")))
-    }
-
-    @Test
-    fun shouldDisplayStateWhenClickingButtonWithCollapsedPanel() {
-        onView(withId(R.id.ds_expansion_panel_container))
-            .perform(click())
-            .perform(click())
-        onView(withId(R.id.current_state_button)).perform(click())
-
-        onView(withId(R.id.current_state_text)).check(matches(withText("The panel is collapsed.")))
+        onView(allOf(
+            withId(R.id.ds_expansion_panel_content_area),
+            isDescendantOfA(withId(R.id.first_expansion_panel))
+        )).check(matches(not(isDisplayed())))
     }
 }

--- a/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
@@ -4,14 +4,12 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.RootMatchers.withDecorView
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.natura.android.sample.R
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.Before
@@ -21,12 +19,9 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class ExpansionPanelActivityTest {
 
-    private lateinit var activity: ExpansionPanelActivity
-
     @Before
     fun setup() {
         ActivityScenario.launch(ExpansionPanelActivity::class.java)
-            .onActivity { activity = it }
     }
 
     @Test
@@ -49,9 +44,7 @@ class ExpansionPanelActivityTest {
     fun shouldDisplayToastWhenExpandingContent() {
         onView(withId(R.id.ds_expansion_panel_container)).perform(click())
 
-        onView(withText("The panel expanded."))
-            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
-            .check(matches(isDisplayed()))
+        onView(withId(R.id.last_action_text)).check(matches(withText("The panel expanded.")))
     }
 
     @Test
@@ -75,18 +68,14 @@ class ExpansionPanelActivityTest {
             .perform(click())
             .perform(click())
 
-        onView(withText("The panel collapsed."))
-            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
-            .check(matches(isDisplayed()))
+        onView(withId(R.id.last_action_text)).check(matches(withText("The panel collapsed.")))
     }
 
     @Test
     fun shouldDisplayCollapsedWhenClickingButtonOnLaunch() {
         onView(withId(R.id.current_state_button)).perform(click())
 
-        onView(withText("The panel is collapsed."))
-            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
-            .check(matches(isDisplayed()))
+        onView(withId(R.id.current_state_text)).check(matches(withText("The panel is collapsed.")))
     }
 
     @Test
@@ -94,9 +83,7 @@ class ExpansionPanelActivityTest {
         onView(withId(R.id.ds_expansion_panel_container)).perform(click())
         onView(withId(R.id.current_state_button)).perform(click())
 
-        onView(withText("The panel is expanded."))
-            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
-            .check(matches(isDisplayed()))
+        onView(withId(R.id.current_state_text)).check(matches(withText("The panel is expanded.")))
     }
 
     @Test
@@ -106,8 +93,6 @@ class ExpansionPanelActivityTest {
             .perform(click())
         onView(withId(R.id.current_state_button)).perform(click())
 
-        onView(withText("The panel is collapsed."))
-            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
-            .check(matches(isDisplayed()))
+        onView(withId(R.id.current_state_text)).check(matches(withText("The panel is collapsed.")))
     }
 }

--- a/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
+++ b/sample/src/androidTest/kotlin/com/natura/android/sample/components/ExpansionPanelActivityTest.kt
@@ -4,9 +4,14 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.RootMatchers.withDecorView
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.natura.android.sample.R
+import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.Before
@@ -16,9 +21,12 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class ExpansionPanelActivityTest {
 
+    private lateinit var activity: ExpansionPanelActivity
+
     @Before
     fun setup() {
         ActivityScenario.launch(ExpansionPanelActivity::class.java)
+            .onActivity { activity = it }
     }
 
     @Test
@@ -38,6 +46,15 @@ class ExpansionPanelActivityTest {
     }
 
     @Test
+    fun shouldDisplayToastWhenExpandingContent() {
+        onView(withId(R.id.ds_expansion_panel_container)).perform(click())
+
+        onView(withText("The panel expanded."))
+            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
     fun shouldRenderGivenComponentsInsideContainer() {
         onView(withId(R.id.ds_expansion_panel_container)).perform(click())
         onView(allOf(withId(R.id.circle_example), withParent(withId(R.id.ds_expansion_panel_content_area))))
@@ -50,5 +67,47 @@ class ExpansionPanelActivityTest {
     fun shouldRenderCollapseWhenClickedOnExpandedContent() {
         onView(withId(R.id.ds_expansion_panel_container)).perform(click()).perform(click())
         onView(withId(R.id.ds_expansion_panel_content_area)).check(matches(not(isDisplayed())))
+    }
+
+    @Test
+    fun shouldDisplayToastWhenCollapsingContent() {
+        onView(withId(R.id.ds_expansion_panel_container))
+            .perform(click())
+            .perform(click())
+
+        onView(withText("The panel collapsed."))
+            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldDisplayCollapsedWhenClickingButtonOnLaunch() {
+        onView(withId(R.id.current_state_button)).perform(click())
+
+        onView(withText("The panel is collapsed."))
+            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldDisplayStateWhenClickingButtonWithExpandedPanel() {
+        onView(withId(R.id.ds_expansion_panel_container)).perform(click())
+        onView(withId(R.id.current_state_button)).perform(click())
+
+        onView(withText("The panel is expanded."))
+            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldDisplayStateWhenClickingButtonWithCollapsedPanel() {
+        onView(withId(R.id.ds_expansion_panel_container))
+            .perform(click())
+            .perform(click())
+        onView(withId(R.id.current_state_button)).perform(click())
+
+        onView(withText("The panel is collapsed."))
+            .inRoot(withDecorView(not(isEqualTo(activity.window.decorView))))
+            .check(matches(isDisplayed()))
     }
 }

--- a/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
@@ -2,8 +2,6 @@ package com.natura.android.sample.components
 
 import android.os.Bundle
 import android.view.MenuItem
-import android.widget.Button
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.natura.android.expansionPanel.ExpansionPanel
 import com.natura.android.sample.R
@@ -21,26 +19,28 @@ class ExpansionPanelActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = "Expansion Panel"
 
-        val currentStateButton = findViewById<Button>(R.id.current_state_button)
-        val currentStateText = findViewById<TextView>(R.id.current_state_text)
-        val lastActionText = findViewById<TextView>(R.id.last_action_text)
-        val expansionPanel = findViewById<ExpansionPanel>(R.id.first_expansion_panel)
+        val expansionPanel1 = findViewById<ExpansionPanel>(R.id.first_expansion_panel)
+        val expansionPanel2 = findViewById<ExpansionPanel>(R.id.second_expansion_panel)
 
-        expansionPanel.setOnStateChangeListener { isExpanded ->
-            val action = if (isExpanded) "expanded" else "collapsed"
-
-            lastActionText.text = "The panel $action."
-        }
-
-        currentStateButton.setOnClickListener {
-            val state = if (expansionPanel.isExpanded()) "expanded" else "collapsed"
-
-            currentStateText.text = "The panel is $state."
-        }
+        listOf(expansionPanel1, expansionPanel2).toggleVisibility()
     }
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         onBackPressed()
         return true
+    }
+
+    private fun List<ExpansionPanel>.toggleVisibility() {
+        forEach { expansionPanel ->
+            expansionPanel.setOnStateChangeListener { isOpen ->
+                if (isOpen) {
+                    filter {
+                        it != expansionPanel && it.isExpanded
+                    }.map { otherExpansionPanel ->
+                        otherExpansionPanel.isExpanded = false
+                    }
+                }
+            }
+        }
     }
 }

--- a/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
@@ -2,7 +2,9 @@ package com.natura.android.sample.components
 
 import android.os.Bundle
 import android.view.MenuItem
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.natura.android.expansionPanel.ExpansionPanel
 import com.natura.android.sample.R
 import com.natura.android.sample.setChosenDefaultTheme
 
@@ -17,6 +19,18 @@ class ExpansionPanelActivity : AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = "Expansion Panel"
+
+        setupExpansionPanelFeatures()
+    }
+
+    private fun setupExpansionPanelFeatures() {
+        val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
+
+        expansionPanel.setOnStateChangeListener { isExpanded ->
+            val action = if (isExpanded) "expanded" else "collapsed"
+
+            Toast.makeText(this, "The panel $action.", Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {

--- a/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
@@ -2,6 +2,7 @@ package com.natura.android.sample.components
 
 import android.os.Bundle
 import android.view.MenuItem
+import android.widget.Button
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.natura.android.expansionPanel.ExpansionPanel
@@ -20,16 +21,19 @@ class ExpansionPanelActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = "Expansion Panel"
 
-        setupExpansionPanelFeatures()
-    }
-
-    private fun setupExpansionPanelFeatures() {
         val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
+        val currentStateButton = findViewById<Button>(R.id.current_state_button)
 
         expansionPanel.setOnStateChangeListener { isExpanded ->
             val action = if (isExpanded) "expanded" else "collapsed"
 
             Toast.makeText(this, "The panel $action.", Toast.LENGTH_SHORT).show()
+        }
+
+        currentStateButton.setOnClickListener {
+            val state = if (expansionPanel.isExpanded()) "expanded" else "collapsed"
+
+            Toast.makeText(this, "The panel is $state.", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.widget.Button
 import android.widget.TextView
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.natura.android.expansionPanel.ExpansionPanel
 import com.natura.android.sample.R

--- a/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
@@ -21,10 +21,10 @@ class ExpansionPanelActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = "Expansion Panel"
 
-        val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
         val currentStateButton = findViewById<Button>(R.id.current_state_button)
         val currentStateText = findViewById<TextView>(R.id.current_state_text)
         val lastActionText = findViewById<TextView>(R.id.last_action_text)
+        val expansionPanel = findViewById<ExpansionPanel>(R.id.first_expansion_panel)
 
         expansionPanel.setOnStateChangeListener { isExpanded ->
             val action = if (isExpanded) "expanded" else "collapsed"

--- a/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/ExpansionPanelActivity.kt
@@ -3,6 +3,7 @@ package com.natura.android.sample.components
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.Button
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.natura.android.expansionPanel.ExpansionPanel
@@ -23,17 +24,19 @@ class ExpansionPanelActivity : AppCompatActivity() {
 
         val expansionPanel = findViewById<ExpansionPanel>(R.id.expansion_panel)
         val currentStateButton = findViewById<Button>(R.id.current_state_button)
+        val currentStateText = findViewById<TextView>(R.id.current_state_text)
+        val lastActionText = findViewById<TextView>(R.id.last_action_text)
 
         expansionPanel.setOnStateChangeListener { isExpanded ->
             val action = if (isExpanded) "expanded" else "collapsed"
 
-            Toast.makeText(this, "The panel $action.", Toast.LENGTH_SHORT).show()
+            lastActionText.text = "The panel $action."
         }
 
         currentStateButton.setOnClickListener {
             val state = if (expansionPanel.isExpanded()) "expanded" else "collapsed"
 
-            Toast.makeText(this, "The panel is $state.", Toast.LENGTH_SHORT).show()
+            currentStateText.text = "The panel is $state."
         }
     }
 

--- a/sample/src/main/res/layout/activity_expansion_panel.xml
+++ b/sample/src/main/res/layout/activity_expansion_panel.xml
@@ -59,7 +59,7 @@
             android:id="@+id/current_state_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Check ExpansionPanel's\ncurrent state"/>
+            android:text="Check ExpansionPanel's\n current state"/>
         
         <TextView
             android:id="@+id/current_state_text"

--- a/sample/src/main/res/layout/activity_expansion_panel.xml
+++ b/sample/src/main/res/layout/activity_expansion_panel.xml
@@ -17,10 +17,10 @@
         android:animateLayoutChanges="true">
 
         <com.natura.android.expansionPanel.ExpansionPanel
-            android:id="@+id/expansion_panel"
+            android:id="@+id/first_expansion_panel"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:title="Expansion Panel">
+            app:title="Expansion Panel 1">
 
             <LinearLayout
                 android:id="@+id/circle_example"

--- a/sample/src/main/res/layout/activity_expansion_panel.xml
+++ b/sample/src/main/res/layout/activity_expansion_panel.xml
@@ -49,11 +49,23 @@
 
         </com.natura.android.expansionPanel.ExpansionPanel>
 
-        <Button
-            android:id="@+id/current_state_button"
+        <TextView
+            android:id="@+id/last_action_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textAppearance="?textAppearanceCaption" />
+
+        <Button
+            android:id="@+id/current_state_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:text="Check ExpansionPanel's\ncurrent state"/>
+        
+        <TextView
+            android:id="@+id/current_state_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?textAppearanceCaption" />
 
     </LinearLayout>
 

--- a/sample/src/main/res/layout/activity_expansion_panel.xml
+++ b/sample/src/main/res/layout/activity_expansion_panel.xml
@@ -17,6 +17,7 @@
         android:animateLayoutChanges="true">
 
         <com.natura.android.expansionPanel.ExpansionPanel
+            android:id="@+id/expansion_panel"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:title="Expansion Panel">

--- a/sample/src/main/res/layout/activity_expansion_panel.xml
+++ b/sample/src/main/res/layout/activity_expansion_panel.xml
@@ -49,6 +49,12 @@
 
         </com.natura.android.expansionPanel.ExpansionPanel>
 
+        <Button
+            android:id="@+id/current_state_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Check ExpansionPanel's\ncurrent state"/>
+
     </LinearLayout>
 
 </ScrollView>

--- a/sample/src/main/res/layout/activity_expansion_panel.xml
+++ b/sample/src/main/res/layout/activity_expansion_panel.xml
@@ -49,23 +49,27 @@
 
         </com.natura.android.expansionPanel.ExpansionPanel>
 
-        <TextView
-            android:id="@+id/last_action_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?textAppearanceCaption" />
-
-        <Button
-            android:id="@+id/current_state_button"
+        <com.natura.android.expansionPanel.ExpansionPanel
+            android:id="@+id/second_expansion_panel"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Check ExpansionPanel's\n current state"/>
-        
-        <TextView
-            android:id="@+id/current_state_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?textAppearanceCaption" />
+            app:title="Expansion Panel 2">
+
+            <TextView
+                android:id="@+id/listener_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="Details\n\nThere's a state change listener in this sample collapsing one ExpansionPanel when the other one expands."
+                android:layout_marginTop="0dp"
+                android:layout_marginLeft="?spacingSmall"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                android:textAppearance="?textAppearanceBody1"
+                android:textColor="?colorOnSurface"/>
+
+        </com.natura.android.expansionPanel.ExpansionPanel>
 
     </LinearLayout>
 


### PR DESCRIPTION
# Description

This PR adds the possibility of getting/setting the ExpansionPanel's current state and adds a listener that is invoked when the state changes. With these methods it'll be possible to react to the state changes and trigger other functions. This is needed to, among other things, unblock [this JIRA task](https://natura.atlassian.net/browse/NFS-1181).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] ExpansionPanelTest
- [x] ExpansionPanelActivityTest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
        Didn't comment it, let me know if you think it's necessary.
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
