### PR TITLE
chore: replace commited by committed on Typo CI

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -24,11 +24,13 @@ excluded_words:
   - androidx
   - appbar
   - appcompat
+  - committed
   - CoreMatchers
   - dimen
   - dimens
   - drawables
   - enum
+  - gradlew
   - jimmyandrade
   - kotlinx
   - Matchers
@@ -56,7 +58,5 @@ excluded_words:
   - xhdpi
   - xxhdpi
   - xxxhdpi
-  - commited
-  - gradlew
 
 spellcheck_filenames: true


### PR DESCRIPTION
# Description

This PR replaces typo "commited" with "committed" (with two T's).
No dependencies were added or removed in this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] This is an internal change (chore)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
