### PR TITLE
fix(appbar): remove excessive spacing between actionbuttons

### DIFF
--- a/designsystem/src/main/res/values/styles.xml
+++ b/designsystem/src/main/res/values/styles.xml
@@ -158,7 +158,6 @@
         <item name="android:layout_height">@dimen/ds_toolbar_height</item>
         <item name="navigationIcon">@drawable/outlined_navigation_directionright</item>
         <item name="collapseIcon">@drawable/outlined_navigation_directionright</item>
-        <item name="actionButtonStyle">@style/ActionButton</item>
     </style>
 
     <style name="Theme.DS.Toolbar" parent="ThemeOverlay.MaterialComponents.Toolbar.Primary">
@@ -166,7 +165,6 @@
         <item name="colorControlNormal">?colorOnSurface</item>
         <item name="navigationIcon">@drawable/outlined_navigation_directionright</item>
         <item name="collapseIcon">@drawable/outlined_navigation_directionright</item>
-        <item name="actionButtonStyle">@style/ActionButton</item>
     </style>
 
     <style name="Widget.DS.Toolbar.Primary" parent="Widget.DS.AppBarTop">
@@ -179,11 +177,6 @@
         <item name="android:background">?colorSecondary</item>
         <item name="android:textColor">?colorOnSecondary</item>
         <item name="titleTextColor">?colorOnSecondary</item>
-    </style>
-
-    <style name="ActionButton" parent="@android:style/Widget.ActionButton">
-        <item name="paddingEnd">?spacingTiny</item>
-        <item name="paddingStart">?spacingTiny</item>
     </style>
 
     <!-- SELECTION CONTROL STYLES -->


### PR DESCRIPTION
# Description

This refactor corrects the excessive spacing error between the ActionButtons items in the toolbar.

Current
![Captura de Tela 2020-07-28 às 18 09 48](https://user-images.githubusercontent.com/67166895/88722835-4bc9ac00-d0fe-11ea-908b-6dad13991e67.png)

How should be

![Captura de Tela 2020-07-28 às 18 05 08](https://user-images.githubusercontent.com/67166895/88722876-5a17c800-d0fe-11ea-9488-3ba38fb4a569.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node version: X.Y.Z
* Yarn version: X.Y.Z

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
