### PR TITLE
[DSY-1469] removing shortcut maxWidth

### DIFF
--- a/designsystem/src/main/res/layout/shortcut.xml
+++ b/designsystem/src/main/res/layout/shortcut.xml
@@ -4,11 +4,11 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/shortcutMainContainer"
-    android:layout_width="64dp"
+    android:minWidth="56dp"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginStart="?spacingSmall"
-    android:layout_marginEnd="?spacingSmall"
-    tools:theme="@style/Theme.Natura">
+    android:layout_marginEnd="?spacingSmall">
 
     <LinearLayout
         android:id="@+id/shortcutRippleBackground"
@@ -50,8 +50,10 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="?spacingTiny"
         android:textAlignment="center"
-        tools:text="Shortcut big label to check the behavior"
+        tools:text="Contained big label to check the behavior"
+        android:autoSizeTextType="uniform"
         android:textAppearance="?textAppearanceCaption"
+        android:singleLine="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/sample/src/main/res/layout/activity_shortcut.xml
+++ b/sample/src/main/res/layout/activity_shortcut.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/shortcutContainer"
@@ -17,7 +18,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/shortcutContained2"
         app:layout_constraintTop_toTopOf="parent"
-        app:textLabel="Contained/ Primary"
+        app:textLabel="Contained/ \nPrimary"
         app:type="contained" />
 
     <com.natura.android.shortcut.Shortcut
@@ -31,7 +32,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/shortcutContained3"
         app:layout_constraintTop_toTopOf="parent"
-        app:textLabel="Contained/ Primary"
+        app:textLabel="Contained/ \nPrimary"
         app:type="contained" />
 
     <com.natura.android.shortcut.Shortcut
@@ -45,7 +46,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/shortcutContained4"
         app:layout_constraintTop_toTopOf="parent"
-        app:textLabel="Contained/ Primary"
+        app:textLabel="Contained/ \nPrimary"
         app:type="contained" />
 
     <com.natura.android.shortcut.Shortcut
@@ -59,7 +60,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:textLabel="Contained/ Primary"
+        app:textLabel="Contained/ \nPrimary"
         app:type="contained" />
 
     <com.natura.android.shortcut.Shortcut
@@ -72,7 +73,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/shortcutOutlined2"
         app:layout_constraintTop_toBottomOf="@+id/shortcutContained1"
-        app:textLabel="Outlined/ Primary"
+        app:textLabel="Outlined/ \nPrimary"
         app:type="outlined" />
 
     <com.natura.android.shortcut.Shortcut
@@ -86,7 +87,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/shortcutOutlined3"
         app:layout_constraintTop_toBottomOf="@+id/shortcutContained2"
-        app:textLabel="Outlined/ Primary"
+        app:textLabel="Outlined/ \nPrimary"
         app:type="outlined" />
 
     <com.natura.android.shortcut.Shortcut
@@ -100,7 +101,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/shortcutOutlined4"
         app:layout_constraintTop_toBottomOf="@+id/shortcutContained3"
-        app:textLabel="Outlined/ Primary"
+        app:textLabel="Outlined/ \nPrimary"
         app:type="outlined" />
 
     <com.natura.android.shortcut.Shortcut
@@ -114,7 +115,7 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/shortcutContained4"
-        app:textLabel="Outlined/ Primary"
+        app:textLabel="Outlined/ \nPrimary"
         app:type="outlined" />
 
     <TextView


### PR DESCRIPTION
# Description

Adjusting shortcut minWidth to prevent label content break


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
