### PR TITLE
chore: updated link Natura Group in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![release](https://img.shields.io/github/v/release/natura-cosmeticos/natds-android?style=for-the-badge)
 
 ## What for
-Library with Android components defined by [Natura Group Design System Team](https://zeroheight.com/08f80f4e1/p/335165-natds--natura-design-system).
+Library with Android components defined by [Natura Group Design System Team](https://zeroheight.com/28db352be/p/35bf2e-natds--natura-design-system).
 
 ## How to use
 


### PR DESCRIPTION
# Description

The old link is deprecated, I just set the correct link.

## Type of change

- [X] Chore (no production code change)


# How Has This Been Tested?

Click on the link to go to Natura Group


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
