### PR TITLE
[DSY-1442] - Adds constructor on DialogStandard class to acce…

### DIFF
--- a/designsystem/src/main/kotlin/com/natura/android/dialog/DialogStandard.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/dialog/DialogStandard.kt
@@ -6,7 +6,7 @@ import android.util.TypedValue
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.natura.android.R
-import kotlinx.android.synthetic.main.dialog_standard_content.view.*
+import kotlinx.android.synthetic.main.dialog_standard_content.view.txtViewId
 
 class DialogStandard private constructor (
     private val context: Context,

--- a/designsystem/src/main/kotlin/com/natura/android/dialog/DialogStandard.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/dialog/DialogStandard.kt
@@ -6,11 +6,13 @@ import android.util.TypedValue
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.natura.android.R
+import kotlinx.android.synthetic.main.dialog_standard_content.view.*
 
 class DialogStandard private constructor (
     private val context: Context,
     private val dialogTitle: String,
     private val mainButtonTitle: String,
+    private val text: String? = null,
     private val mainButtonAction: DialogInterface.OnClickListener,
     private val secondaryButtonTitle: String,
     private val secondaryButtonAction: DialogInterface.OnClickListener,
@@ -38,6 +40,7 @@ class DialogStandard private constructor (
             mainButtonAction = mainButtonAction,
             secondaryButtonTitle = secondaryButtonTitle,
             secondaryButtonAction = secondaryButtonAction,
+            text = null,
             contentLayout = null,
             contentView = contentView,
             isCancelable = isCancelable,
@@ -62,7 +65,33 @@ class DialogStandard private constructor (
             mainButtonAction = mainButtonAction,
             secondaryButtonTitle = secondaryButtonTitle,
             secondaryButtonAction = secondaryButtonAction,
+            text = null,
             contentLayout = contentLayout,
+            contentView = null,
+            isCancelable = isCancelable,
+            dialogTheme = dialogTheme)
+
+    @JvmOverloads
+    constructor(
+        context: Context,
+        dialogTitle: String,
+        mainButtonTitle: String,
+        mainButtonAction: DialogInterface.OnClickListener,
+        secondaryButtonTitle: String,
+        secondaryButtonAction: DialogInterface.OnClickListener,
+        text: String,
+        isCancelable: Boolean = true,
+        dialogTheme: Int? = null
+    ) :
+        this(
+            context = context,
+            dialogTitle = dialogTitle,
+            mainButtonTitle = mainButtonTitle,
+            mainButtonAction = mainButtonAction,
+            secondaryButtonTitle = secondaryButtonTitle,
+            secondaryButtonAction = secondaryButtonAction,
+            text = text,
+            contentLayout = null,
             contentView = null,
             isCancelable = isCancelable,
             dialogTheme = dialogTheme)
@@ -75,6 +104,13 @@ class DialogStandard private constructor (
             setButton(DialogInterface.BUTTON_POSITIVE, mainButtonTitle, mainButtonAction)
             setButton(DialogInterface.BUTTON_NEGATIVE, secondaryButtonTitle, secondaryButtonAction)
             setCancelable(isCancelable)
+
+            text?.let {
+                layoutInflater.inflate(R.layout.dialog_standard_content, null).apply {
+                    setView(this)
+                    this.txtViewId.text = text
+                }
+            }
             contentView?.let { setView(contentView) }
             contentLayout?.let { setView(layoutInflater.inflate(it, null)) }
         }

--- a/designsystem/src/main/res/layout/dialog_standard_content.xml
+++ b/designsystem/src/main/res/layout/dialog_standard_content.xml
@@ -9,6 +9,7 @@
     android:layout_height="wrap_content">
 
     <TextView
+        android:id="@+id/txtViewId"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/designsystem/src/test/kotlin/com/natura/android/dialog/DialogStandardTest.kt
+++ b/designsystem/src/test/kotlin/com/natura/android/dialog/DialogStandardTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.natura.android.R
+import kotlinx.android.synthetic.main.dialog_standard_content.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -72,6 +73,16 @@ class DialogStandardTest {
         assertThat(dialogCustomContent?.childCount).isEqualTo(1)
     }
 
+    @Test
+    fun checksDialogCustomText() {
+        dialog = createDialogWithCustomText()
+        dialog.show()
+
+        val dialogCustomContent = dialog.dialog.txtViewId.text
+
+        assertThat(dialogCustomContent).isEqualTo("Text Example")
+    }
+
     private fun createDialogWithCustomContentFromResourceId(): DialogStandard {
         return DialogStandard(
             context,
@@ -80,7 +91,7 @@ class DialogStandardTest {
             DialogInterface.OnClickListener { _, _ -> },
             "Secondary Button",
             DialogInterface.OnClickListener { _, _ -> },
-            R.layout.test_dialog_content).create()
+            R.layout.dialog_standard_content).create()
     }
 
     private fun createDialogWithCustomContentFromView(): DialogStandard {
@@ -95,5 +106,19 @@ class DialogStandardTest {
             "Secondary Button",
             DialogInterface.OnClickListener { _, _ -> },
             view).create()
+    }
+
+    private fun createDialogWithCustomText(): DialogStandard {
+        val view = ImageView(context)
+        view.setImageResource(R.drawable.default_icon_outlined_default_mockup)
+
+        return DialogStandard(
+            context,
+            "Dialog Title",
+            "Main Button",
+            DialogInterface.OnClickListener { _, _ -> },
+            "Secondary Button",
+            DialogInterface.OnClickListener { _, _ -> },
+            "Text Example").create()
     }
 }

--- a/sample/src/main/kotlin/com/natura/android/sample/components/DialogActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/DialogActivity.kt
@@ -45,6 +45,6 @@ class DialogActivity : AppCompatActivity() {
             mainClickListener,
             "Close",
             secondaryClickListener,
-            R.layout.test_dialog_content).create()
+            R.layout.dialog_standard_content).create()
     }
 }


### PR DESCRIPTION
# Description

Another constructor was added to the DialogStandard component class, due to a new parameter that receives the text that is displayed in the Dialog message.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Unit tests (DialogStandardTest.kt)
- [ ] Screenshot tests ()

**Test Configuration**:
* Pixel 2 API 29

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
