### PR TITLE
[DSY-2384] - Change navigationIcon to assignable at StandardAppBarTop

### DIFF
--- a/designsystem/src/main/kotlin/com/natura/android/appbartop/StandardAppBarTop.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/appbartop/StandardAppBarTop.kt
@@ -97,7 +97,7 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        resetProperties()
+        resetProperty()
         positionActions()
         throwsCountElementsException()
         changeActionsVisibility()
@@ -228,9 +228,8 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
         }
     }
 
-    private fun resetProperties() {
+    private fun resetProperty() {
         toolbar.title = ""
-        toolbar.navigationIcon = null
     }
 
     private fun getAttributes() {

--- a/sample/src/main/kotlin/com/natura/android/sample/components/AppBarTopActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/AppBarTopActivity.kt
@@ -9,6 +9,7 @@ import com.natura.android.iconButton.IconButton
 import com.natura.android.sample.R
 import com.natura.android.sample.setChosenDefaultWithNoActionBarTheme
 import kotlinx.android.synthetic.main.appbartop_button_action.view.*
+import kotlinx.android.synthetic.main.appbartop_threeactions.view.appBar
 
 class AppBarTopActivity : AppCompatActivity() {
 
@@ -50,6 +51,10 @@ class AppBarTopActivity : AppCompatActivity() {
         val pattern = intent.getIntExtra("pattern", PATTERN_APPBARTOP_TWOACTIONS)
 
         setContentView(R.layout.activity_appbar_top)
+
+        setSupportActionBar(appBarTopWithThreeActions.appBar.toolbar)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(false)
 
         createListeners()
 


### PR DESCRIPTION
# Description

Fix navigationIcon at StandardAppBar Top to become assignable.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
