### PR TITLE
[DSY-2470] - Title at StandardAppBarTop is not aligned when set dyanamically

### DIFF
--- a/designsystem/src/main/kotlin/com/natura/android/appbartop/StandardAppBarTop.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/appbartop/StandardAppBarTop.kt
@@ -178,18 +178,11 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
                 positionActionRight()
             }
         }
-
-        if (childCount > MIN_COUNT_ELEMENTS) {
-            positionActionCenter()
-        }
     }
 
-    private fun positionActionCenter() {
-        val child = getChildAt(1)
-        this.removeView(child)
-
+    private fun addContentView(view: View) {
         if (proeminentContent) {
-            actionLeftContainer.addView(child)
+            actionLeftContainer.addView(view)
             actionLeftContainer.layoutParams = LinearLayout.LayoutParams(
                 LayoutParams.WRAP_CONTENT,
                 LayoutParams.WRAP_CONTENT,
@@ -198,9 +191,8 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
             actionLeftContainer.orientation = LinearLayout.VERTICAL
             actionCenterContainer.setVisibilityFromBoolean(false)
         } else {
-
-            actionCenterContainer.gravity = getContentAlign(context)
-            actionCenterContainer.addView(child)
+            actionCenterContainer.gravity = Gravity.CENTER
+            actionCenterContainer.addView(view)
         }
     }
 
@@ -331,7 +323,7 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
                 mediaWidth,
                 mediaHeight
             )
-        addView(imageView)
+        addContentView(imageView)
     }
 
     private fun addTextView(context: Context, text: String) {
@@ -354,7 +346,7 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
         textView.ellipsize = TextUtils.TruncateAt.END
         textView.setLines(1)
 
-        addView(textView)
+        addContentView(textView)
     }
 
     private fun addTextField(context: Context) {
@@ -365,7 +357,7 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
                 MATCH_PARENT,
                 WRAP_CONTENT
             )
-        addView(textField)
+        addContentView(textField)
     }
 
     private fun getContentAlign(context: Context): Int {
@@ -417,9 +409,9 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
 
         private const val MINIMUM_SCREEN_SIZE_FOR_CENTRALIZED_LOGO = 361
         private const val MAX_COUNT_ELEMENTS = 5
-        private const val COUNT_ELEMENTS_ONLY_ACTION_LEFT = 3
-        private const val ACTION_LEFT_ELEMENT_INDEX = 2
-        private const val ACTION_RIGHT_FIRST_ELEMENT_INDEX = 2
+        private const val COUNT_ELEMENTS_ONLY_ACTION_LEFT = 2
+        private const val ACTION_LEFT_ELEMENT_INDEX = 1
+        private const val ACTION_RIGHT_FIRST_ELEMENT_INDEX = 1
         private const val MIN_COUNT_ELEMENTS = 1
 
         private const val NOT_RESOURCE_FOUND_CODE = 0

--- a/designsystem/src/main/kotlin/com/natura/android/appbartop/StandardAppBarTop.kt
+++ b/designsystem/src/main/kotlin/com/natura/android/appbartop/StandardAppBarTop.kt
@@ -191,6 +191,7 @@ class StandardAppBarTop(context: Context, attrs: AttributeSet) : AppBarLayout(co
             actionLeftContainer.orientation = LinearLayout.VERTICAL
             actionCenterContainer.setVisibilityFromBoolean(false)
         } else {
+            actionCenterContainer.removeAllViews()
             actionCenterContainer.gravity = Gravity.CENTER
             actionCenterContainer.addView(view)
         }

--- a/sample/src/main/kotlin/com/natura/android/sample/components/AppBarTopActivity.kt
+++ b/sample/src/main/kotlin/com/natura/android/sample/components/AppBarTopActivity.kt
@@ -8,8 +8,8 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.natura.android.iconButton.IconButton
 import com.natura.android.sample.R
 import com.natura.android.sample.setChosenDefaultWithNoActionBarTheme
-import kotlinx.android.synthetic.main.appbartop_button_action.view.*
 import kotlinx.android.synthetic.main.appbartop_threeactions.view.appBar
+import kotlinx.android.synthetic.main.appbartop_title_center.view.appBarTitleCenter
 
 class AppBarTopActivity : AppCompatActivity() {
 
@@ -53,6 +53,8 @@ class AppBarTopActivity : AppCompatActivity() {
         setContentView(R.layout.activity_appbar_top)
 
         setSupportActionBar(appBarTopWithThreeActions.appBar.toolbar)
+
+        appBarTopWithTitleCenter.appBarTitleCenter.setText("Title Center")
 
         supportActionBar?.setDisplayHomeAsUpEnabled(false)
 

--- a/sample/src/main/res/layout/appbartop_title_center.xml
+++ b/sample/src/main/res/layout/appbartop_title_center.xml
@@ -15,7 +15,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <com.natura.android.appbartop.StandardAppBarTop
-            android:id="@+id/appBar"
+            android:id="@+id/appBarTitleCenter"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="?toolbarDefaultTheme"


### PR DESCRIPTION
# Description

The StandardAppBarTop component title is not center-aligned when dynamically defined by function.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
